### PR TITLE
simplify ExIrc.Client.do_add_handler/2 logic

### DIFF
--- a/lib/exirc/client.ex
+++ b/lib/exirc/client.ex
@@ -443,7 +443,7 @@ defmodule ExIrc.Client do
     end
   end
   # If an event handler process dies, remove it from the list of event handlers
-  def handle_info({'DOWN', _, _, pid, _}, state) do
+  def handle_info({:DOWN, _, _, pid, _}, state) do
     handlers = do_remove_handler(pid, state.event_handlers)
     {:noreply, %{state | :event_handlers => handlers}}
   end
@@ -636,19 +636,11 @@ defmodule ExIrc.Client do
   end
 
   defp do_add_handler(pid, handlers) do
-    node       = Kernel.node(pid)
-    local_node = Kernel.self()
-    should_add? = case node do
-      ^local_node ->
-        Process.alive?(pid) and not Enum.member?(handlers, pid)
-      _ ->
-        :rpc.call(node, :erlang, :is_process_alive, [pid]) and not Enum.member?(handlers, pid)
-    end
-    case should_add? do
-      true ->
+    case Enum.member?(handlers, pid) do
+      false ->
         ref = Process.monitor(pid)
         [{pid, ref} | handlers]
-      false ->
+      true ->
         handlers
     end
   end


### PR DESCRIPTION
Prior to this commit the `do_add_handler` function would do lots of work
to check to see if the handler process was alive (either on the local
node or a remote node); however, this work not comprehensive because the
process could die between the `alive?` check and `Process.monitor/1`, but
also unneccesary, because the semantics of `Process.monitor/1` (and
`:erlang.monitor/2`) will guarantee that the monitoring process will be
sent a `{:DOWN, _, _, _, _}` message if the monitored process dies,
doesn't exist or the node hosting the process disconnects from the mesh.
Because `Process.monitor/1` notifies the monitoring process if the
monitored process is dead by the time we add it, we can remove the
checks to validate that the handler process is alive and instead rely on
the semantics of `Process.monitor/1` and simplify our logic.
This commit also fixes the handling of the `{:DOWN, _, _, _, _}` message
because previously we were checking for the Erlang variant of it as
`{'DOWN', _, _, _, _}`, and thus, our handler removal upon process death
was never getting properly called.
