### PR TITLE
Allow ExIrc.Client.start_link to use process opts

### DIFF
--- a/lib/exirc/client.ex
+++ b/lib/exirc/client.ex
@@ -50,9 +50,9 @@ defmodule ExIrc.Client do
 
   Returns either {:ok, pid} or {:error, reason}
   """
-  @spec start_link(options :: list() | nil) :: {:ok, pid} | {:error, term}
-  def start_link(options \\ []) do
-    :gen_server.start_link(__MODULE__, options, [])
+  @spec start_link(options :: list() | nil, process_opts :: list() | nil) :: {:ok, pid} | {:error, term}
+  def start_link(options \\ [], process_opts \\ []) do
+    GenServer.start_link(__MODULE__, options, process_opts)
   end
   @doc """
   Stop the IRC client process


### PR DESCRIPTION
Prior to this commit, registering the name for an ExIrc.Client process,
it was a two-step process of `ExIrc.Client.start_link` and then
`Process.register`. This also made registering a name for
supervisor-started `ExIrc.Client` processes a bit tricky. This commit
allows end users to start `ExIrc.Client` processes from a supervisor,
but still register a name, as in the example below.

```
    children = [
      worker(ExIrc.Client, [[debug: true], [name: :irc_client]])
      ]
    supervise(children, strategy: :one_for_all)
```