### PR TITLE
Relax Elixir version requirement

### DIFF
--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule ExIrc.Mixfile do
   def project do
     [ app: :exirc,
       version: "0.9.1",
-      elixir: "~> 1.0.0",
+      elixir: "~> 1.0",
       description: "An IRC client library for Elixir.",
       package: package,
       deps: [] ]


### PR DESCRIPTION
Currently, ExIrc specifies its Elixir version to `1.0.0`. This will result in a warning message when compiling on anything newer than `1.0.x`, e.g. the latest elixir master, which is currently `1.1-dev`. Relaxing this version requirement will remove this warning message, and since Elixir follows Semantic Versioning, this should not be an issue.