### PR TITLE
Adding :names_list event on getting names list

### DIFF
--- a/lib/exirc/client.ex
+++ b/lib/exirc/client.ex
@@ -576,6 +576,9 @@ defmodule ExIrc.Client do
       Channels.users_join(state.channels, channel, String.split(names, " ", trim: true)),
       channel,
       channel_type)
+
+    send_event({:names_list, channel, names}, state)
+
     {:noreply, %{state | :channels => channels}}
   end
   # Called when our nick has succesfully changed


### PR DESCRIPTION
The names list is blank when "joining" a channel, and wanted to get the names list when it was available. Not sure of the formatting of the arguments or if its a good idea or not. 

If there is a better way to do this, I'd be down for using that.

Thanks for this great IRC client =)