### PR TITLE
Send an event for unrecognized messages

### DIFF
--- a/lib/exirc/client.ex
+++ b/lib/exirc/client.ex
@@ -683,6 +683,7 @@ defmodule ExIrc.Client do
   # Called any time we receive an unrecognized message
   def handle_data(msg, state) do
     if state.debug? do debug "UNRECOGNIZED MSG: #{msg.cmd}"; IO.inspect(msg) end
+    send_event {:unrecognized, msg.cmd, msg}, state
     {:noreply, state}
   end
 


### PR DESCRIPTION
This way for things that are unsupported like CAP things (with twitch specifically tested), we can handle almost anything.

(In relation to this issue: https://github.com/bitwalker/exirc/issues/28)