### PR TITLE
Replace erlang.now() by the more appropriate 'timestamp'

### DIFF
--- a/lib/exirc/client.ex
+++ b/lib/exirc/client.ex
@@ -522,7 +522,7 @@ defmodule ExIrc.Client do
   # Called upon successful login
   def handle_data(%IrcMessage{:cmd => @rpl_welcome}, %ClientState{:logged_on? => false} = state) do
     if state.debug?, do: debug "SUCCESFULLY LOGGED ON"
-    new_state = %{state | :logged_on? => true, :login_time => :erlang.now()}
+    new_state = %{state | :logged_on? => true, :login_time => :erlang.timestamp()}
     send_event :logged_in, new_state
     {:noreply, new_state}
   end


### PR DESCRIPTION
A tiny change to ` lib/exirc/client.ex`.

As of OTP 18, erlang:now() is deprecated, see the [Erlang time documentation](http://www.erlang.org/doc/apps/erts/time_correction.html#Dos_and_Donts) for more informations about this issue.