### PR TITLE
use simple one for one supervisor for clients

### DIFF
--- a/lib/exirc/exirc.ex
+++ b/lib/exirc/exirc.ex
@@ -30,6 +30,7 @@ defmodule ExIrc do
 
   """
   use Supervisor
+  import Supervisor.Spec
 
   ##############
   # Public API
@@ -49,7 +50,7 @@ defmodule ExIrc do
   @spec start_client! :: {:ok, pid} | {:error, term}
   def start_client! do
     # Start the client worker
-    :supervisor.start_child(:exirc, worker(ExIrc.Client, []))
+    :supervisor.start_child(:exirc, [])
   end
 
   ##############
@@ -58,7 +59,10 @@ defmodule ExIrc do
 
   @spec init(any) :: {:ok, pid} | {:error, term}
   def init(_) do
-    supervise [], strategy: :one_for_one
+    children = [
+      worker(ExIrc.Client, [], restart: :transient)
+    ]
+    supervise children, strategy: :simple_one_for_one
   end
 
 end

--- a/test/client_test.exs
+++ b/test/client_test.exs
@@ -1,0 +1,11 @@
+defmodule ExIrc.ClientTest do
+  use ExUnit.Case
+
+
+  test "start multiple clients" do
+    {:ok, pid} = ExIrc.start_client!
+    {:ok, pid2} = ExIrc.start_client!
+    assert pid != pid2
+  end
+
+end


### PR DESCRIPTION
this allows starting multiple clients at the same time. before `{:error, :already_started}` was returned when calling `ExIrc.start_client!` twice.