### PR TITLE
handle QUIT messages

### DIFF
--- a/lib/exirc/channels.ex
+++ b/lib/exirc/channels.ex
@@ -118,6 +118,16 @@ defmodule ExIrc.Channels do
     users_manip(channel_tree, channel_name, manipfn)
   end
 
+  def user_quit(channel_tree, nick) do
+    pnick = strip_rank([nick])
+    manipfn = fn(channel_nicks) -> :lists.usort(channel_nicks -- pnick) end
+    foldl = fn(channel_name, new_channel_tree) ->
+      name = downcase(channel_name)
+      users_manip(new_channel_tree, name, manipfn)
+    end
+    :lists.foldl(foldl, channel_tree, channels(channel_tree))
+  end
+
   @doc """
   Update the nick of a user in a tracked channel when they change their nick
   """

--- a/lib/exirc/client.ex
+++ b/lib/exirc/client.ex
@@ -637,6 +637,15 @@ defmodule ExIrc.Client do
     send_event {:parted, channel, sender}, new_state
     {:noreply, new_state}
   end
+  def handle_data(%IrcMessage{cmd: "QUIT", nick: from, host: host, user: user} = msg, state) do
+    sender = %SenderInfo{nick: from, host: host, user: user}
+    reason = msg.args |> List.first
+    if state.debug?, do: debug "#{from} QUIT"
+    channels = Channels.user_quit(state.channels, from)
+    new_state = %{state | channels: channels}
+    send_event {:quit, reason, sender}, new_state
+    {:noreply, new_state}
+  end
   # Called when we receive a PING
   def handle_data(%IrcMessage{cmd: "PING"} = msg, %ClientState{autoping: true} = state) do
     if state.debug?, do: debug "RECEIVED A PING!"

--- a/test/channels_test.exs
+++ b/test/channels_test.exs
@@ -100,6 +100,21 @@ defmodule ExIrc.ChannelsTest do
     assert {:error, :no_such_channel} == Channels.channel_has_user?(channels, "#testchannel", "testnick")
   end
 
+  test "Can quit a user from all channels" do
+    channels =
+      Channels.init()
+      |> Channels.join("#testchannel")
+      |> Channels.user_join("#testchannel", "testnick")
+      |> Channels.join("#anotherchannel")
+      |> Channels.user_join("#anotherchannel", "testnick")
+      |> Channels.user_join("#anotherchannel", "secondnick")
+    assert Channels.channel_has_user?(channels, "#testchannel", "testnick")
+    channels = channels |> Channels.user_quit("testnick")
+    refute Channels.channel_has_user?(channels, "#testchannel", "testnick")
+    refute Channels.channel_has_user?(channels, "#anotherchannel", "testnick")
+    assert Channels.channel_has_user?(channels, "#anotherchannel", "secondnick")
+  end
+
   test "Can rename a user" do
     channels = Channels.init() 
                 |> Channels.join("#testchannel") 


### PR DESCRIPTION
Prior to this commit ExIrc did not know what to do with QUIT messages,
which would result in nicks remaining in the `Channels` data structure
when they should not. This commit implements handling of the QUIT
message and ensures that the new `Channels.user_quit` function is called
to flush the departing user from all known channels.

Close #40