### PR TITLE
Prevent zombie connections

### DIFF
--- a/lib/exirc/exirc.ex
+++ b/lib/exirc/exirc.ex
@@ -60,7 +60,7 @@ defmodule ExIrc do
   @spec init(any) :: {:ok, pid} | {:error, term}
   def init(_) do
     children = [
-      worker(ExIrc.Client, [], restart: :transient)
+      worker(ExIrc.Client, [], restart: :temporary)
     ]
     supervise children, strategy: :simple_one_for_one
   end

--- a/lib/exirc/exirc.ex
+++ b/lib/exirc/exirc.ex
@@ -50,7 +50,7 @@ defmodule ExIrc do
   @spec start_client! :: {:ok, pid} | {:error, term}
   def start_client! do
     # Start the client worker
-    Supervisor.start_child(:exirc, [])
+    Supervisor.start_child(:exirc, [[owner: self()]])
   end
 
   ##############

--- a/test/client_test.exs
+++ b/test/client_test.exs
@@ -1,11 +1,30 @@
 defmodule ExIrc.ClientTest do
   use ExUnit.Case
 
-
   test "start multiple clients" do
-    {:ok, pid} = ExIrc.start_client!
-    {:ok, pid2} = ExIrc.start_client!
+    assert {:ok, pid} = ExIrc.start_client!
+    assert {:ok, pid2} = ExIrc.start_client!
     assert pid != pid2
   end
 
+  test "client dies if owner process dies" do
+    test_pid = self()
+
+    pid = spawn_link(fn ->
+      assert {:ok, pid} = ExIrc.start_client!
+      send(test_pid, {:client, pid})
+      receive do
+        :stop -> :ok
+      end
+    end)
+
+    client_pid = receive do
+      {:client, pid} -> pid
+    end
+
+    assert Process.alive?(client_pid)
+    send(pid, :stop)
+    :timer.sleep(1)
+    refute Process.alive?(client_pid)
+  end
 end


### PR DESCRIPTION
This adds two changes regarding managing connection processes:
* when a connection is started the starting process will be monitored. If that process dies, the connection will die as well
* the supervisor's type is changed to `temporary`. Since starting a connection though the supervisor does not support naming the process, restarting it makes no sense - the pid we initially received is no longer valid after process is restarted by the supervisor.
You can still name the process when starting it outside from the `:exirc` supervisor which makes perfect sense.