### PR TITLE
Fix lint errors with mix

### DIFF
--- a/mix.exs
+++ b/mix.exs
@@ -2,14 +2,14 @@ defmodule ExIrc.Mixfile do
   use Mix.Project
 
   def project do
-    [ app: :exirc,
+    [app: :exirc,
       version: "1.0.0",
       elixir: "~> 1.0",
       description: "An IRC client library for Elixir.",
-      package: package,
+      package: package(),
       test_coverage: [tool: ExCoveralls],
       preferred_cli_env: ["coveralls": :test, "coveralls.detail": :test, "coveralls.html": :test, "coveralls.post": :test],
-      deps: deps ]
+      deps: deps()]
   end
 
   # Configuration for the OTP application


### PR DESCRIPTION
This commit fixes the lint errors that Mix reports when building
ExIRC.

The errors are to do with package and deps being ambigious, and they
should be called *as* functions, not variables.