### PR TITLE
Fix IRC regex handling of slashes in host

### DIFF
--- a/lib/exirc/utils.ex
+++ b/lib/exirc/utils.ex
@@ -25,7 +25,7 @@ defmodule ExIrc.Utils do
     end
   end
 
-  @prefix_pattern ~r/^(?<nick>[^!\s]+)(?:!(?<user>[^@\s]+@)?(?<host>\S+))?$/
+  @prefix_pattern ~r/^(?<nick>[^!\s]+)(?:!(?:(?<user>[^@\s]+)@)?(?:(?<host>[\S]+)))?$/
   defp parse_from(from, msg) do
     from_str = IO.iodata_to_binary(from)
     parts    = Regex.run(@prefix_pattern, from_str, capture: :all_but_first)

--- a/lib/exirc/utils.ex
+++ b/lib/exirc/utils.ex
@@ -25,7 +25,7 @@ defmodule ExIrc.Utils do
     end
   end
 
-  @prefix_pattern ~r/^(?<nick>[^!]+)(?:!(?:(?<user>[^@ ]+)@)?(?:(?<host>\S+[\w.:-]+)))?$/
+  @prefix_pattern ~r/^(?<nick>[^!\s]+)(?:!(?<user>[^@\s]+@)?(?<host>\S+))?$/
   defp parse_from(from, msg) do
     from_str = IO.iodata_to_binary(from)
     parts    = Regex.run(@prefix_pattern, from_str, capture: :all_but_first)

--- a/lib/exirc/utils.ex
+++ b/lib/exirc/utils.ex
@@ -25,7 +25,7 @@ defmodule ExIrc.Utils do
     end
   end
 
-  @prefix_pattern ~r/^(?<nick>[^!]+)(?:!(?:(?<user>[^@ ]+)@)?(?:(?<host>[\w.:-]+)))?$/
+  @prefix_pattern ~r/^(?<nick>[^!]+)(?:!(?:(?<user>[^@ ]+)@)?(?:(?<host>\S+[\w.:-]+)))?$/
   defp parse_from(from, msg) do
     from_str = IO.iodata_to_binary(from)
     parts    = Regex.run(@prefix_pattern, from_str, capture: :all_but_first)

--- a/test/utils_test.exs
+++ b/test/utils_test.exs
@@ -38,6 +38,21 @@ defmodule ExIrc.UtilsTest do
     result = Utils.parse(message)
     assert expected == result
   end
+
+  test "Parse uncloaked (normal) user" do
+    message = ':foo!foo@80.21.56.43 PRIVMSG #bar Hiya.'
+    expected = %IrcMessage{
+      nick: "foo",
+      cmd: "PRIVMSG",
+      host: "80.21.56.43",
+      ctcp: false,
+      user: "foo",
+      args: ["#bar", "Hiya."]
+    }
+    result = Utils.parse(message)
+    assert expected == result
+  end
+
   test "Parse INVITE message" do
     message = ':pschoenf INVITE testuser #awesomechan'
     assert %IrcMessage{

--- a/test/utils_test.exs
+++ b/test/utils_test.exs
@@ -25,6 +25,19 @@ defmodule ExIrc.UtilsTest do
     assert expected == result
   end
 
+  test "Parse cloaked user" do
+    message = ':foo!foo@unaffiliated/foo PRIVMSG #bar Hiya.'
+    expected = %IrcMessage{
+      nick: "foo",
+      cmd: "PRIVMSG",
+      host: "unaffiliated/foo",
+      ctcp: false,
+      user: "foo",
+      args: ["#bar", "Hiya."]
+    }
+    result = Utils.parse(message)
+    assert expected == result
+  end
   test "Parse INVITE message" do
     message = ':pschoenf INVITE testuser #awesomechan'
     assert %IrcMessage{


### PR DESCRIPTION
As per the issue reported in #59, this commit fixes that issue with a
regex patch suggested by @vktec.

This commit has been tested with cloaks, and _appears_ to work, which is
a good improvement.

Because of the improvement, this fixes #59.