### PR TITLE
Add NOTICE support (and by ext, NickServ support)

### DIFF
--- a/lib/exirc/client.ex
+++ b/lib/exirc/client.ex
@@ -728,6 +728,23 @@ defmodule ExIrc.Client do
     send_event {:me, message, sender, channel}, state
     {:noreply, state}
   end
+  # Called when a NOTICE is received by the client.
+  def handle_data(%IrcMessage{nick: from, cmd: "NOTICE", args: [target, message], host: host, user: user} = _msg, state) do
+    sender = %SenderInfo{nick: from,
+                         host: host,
+                         user: user}
+
+    if String.contains?(message, "identify") do
+        if state.debug?, do: debug("* Told to identify by #{from}: #{message}")
+        send_event({:identify, message, sender}, state)
+    else
+      if state.debug?, do: debug("* #{message} from #{sender}")
+      send_event({:notice, message, sender}, state)
+    end
+
+    {:noreply, state}
+  end
+
   # Called any time we receive an unrecognized message
   def handle_data(msg, state) do
     if state.debug? do debug "UNRECOGNIZED MSG: #{msg.cmd}"; IO.inspect(msg) end


### PR DESCRIPTION
This commit adds NOTICE handling support, as well as support for when
the client is told to to identify by NickServ, which /usually/ comes in
the form of a NOTICE. Later versions of this patch should account for
other ways NickServ might ask a client to identify.

(Related to #65)