### PR TITLE
Add "list of projects that use ExIrc" to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -182,7 +182,7 @@ end
 Below is a list of projects that we know of (if we've missed anything,
 send a PR!) that use ExIrc in the wild.
 
-1. [Kuma][kuma] by @ryanwinchester
+- [Kuma][kuma] by @ryanwinchester
 - [Offension][offension] by @shymega
 
 [kuma]: https://github.com/ryanwinchester/kuma

--- a/README.md
+++ b/README.md
@@ -184,6 +184,8 @@ send a PR!) that use ExIrc in the wild.
 
 - [Kuma][kuma] by @ryanwinchester
 - [Offension][offension] by @shymega
+- [hedwig_irc][hedwig_irc] by @jeffweiss
 
 [kuma]: https://github.com/ryanwinchester/kuma
 [offension]: https://github.com/shymega/offension
+[hedwig_irc]: https://github.com/jeffweiss/hedwig_irc

--- a/README.md
+++ b/README.md
@@ -183,7 +183,7 @@ Below is a list of projects that we know of (if we've missed anything,
 send a PR!) that use ExIrc in the wild.
 
 1. [Kuma][kuma] by @ryanwinchester
-2. [Offension][offension] by @shymega
+- [Offension][offension] by @shymega
 
 [kuma]: https://github.com/ryanwinchester/kuma
 [offension]: https://github.com/shymega/offension

--- a/README.md
+++ b/README.md
@@ -176,3 +176,14 @@ defmodule ExampleLoginHandler do
   end
 end
 ```
+
+## Projects using ExIrc (in the wild!)
+
+Below is a list of projects that we know of (if we've missed anything,
+send a PR!) that use ExIrc in the wild.
+
+1. [Kuma][kuma] by @ryanwinchester
+2. [Offension][offension] by @shymega
+
+[kuma]: https://github.com/ryanwinchester/kuma
+[offension]: https://github.com/shymega/offension


### PR DESCRIPTION
This commit meant to provide a list of projects that use ExIrc to the README.

I've added @ryanwinchester 's bot Kuma to the list, as well as my own bot Offension as well.

If there's any other bots to be added, we can add those in later commits.

WDYT?