### PR TITLE
Listen to nickname in use error when logging in

### DIFF
--- a/examples/bot/lib/bot.ex
+++ b/examples/bot/lib/bot.ex
@@ -56,7 +56,7 @@ defmodule Example.Bot do
     Client.join config.client, config.channel
     {:noreply, config}
   end
-  def handle_info({:login_failed, :nickname_in_use}, config) do
+  def handle_info({:login_failed, :nick_in_use}, config) do
     nick = Enum.map(1..8, fn x -> Enum.random('abcdefghijklmnopqrstuvwxyz') end)
     Client.nick config.client, to_string(nick)
     {:noreply, config}

--- a/examples/bot/lib/bot.ex
+++ b/examples/bot/lib/bot.ex
@@ -56,6 +56,11 @@ defmodule Example.Bot do
     Client.join config.client, config.channel
     {:noreply, config}
   end
+  def handle_info({:login_failed, :nickname_in_use}, config) do
+    nick = Enum.map(1..8, fn x -> Enum.random('abcdefghijklmnopqrstuvwxyz') end)
+    Client.nick config.client, to_string(nick)
+    {:noreply, config}
+  end
   def handle_info(:disconnected, config) do
     Logger.debug "Disconnected from #{config.server}:#{config.port}"
     {:stop, :normal, config}

--- a/lib/exirc/client.ex
+++ b/lib/exirc/client.ex
@@ -574,6 +574,12 @@ defmodule ExIRC.Client do
     send_event :logged_in, new_state
     {:noreply, new_state}
   end
+  # Called when trying to log in with a nickname that is in use
+  def handle_data(%IrcMessage{cmd: @err_nickname_in_use}, %ClientState{logged_on?: false} = state) do
+    if state.debug?, do: debug "ERROR: NICKNAME IN USE"
+    send_event {:login_failed, :nickname_in_use}, state
+    {:noreply, state}
+  end
   # Called when the server sends it's current capabilities
   def handle_data(%ExIRC.Message{cmd: @rpl_isupport} = msg, state) do
     if state.debug?, do: debug "RECEIVING SERVER CAPABILITIES"

--- a/lib/exirc/client.ex
+++ b/lib/exirc/client.ex
@@ -575,9 +575,9 @@ defmodule ExIRC.Client do
     {:noreply, new_state}
   end
   # Called when trying to log in with a nickname that is in use
-  def handle_data(%IrcMessage{cmd: @err_nickname_in_use}, %ClientState{logged_on?: false} = state) do
-    if state.debug?, do: debug "ERROR: NICKNAME IN USE"
-    send_event {:login_failed, :nickname_in_use}, state
+  def handle_data(%ExIRC.Message{cmd: @err_nick_in_use}, %ClientState{logged_on?: false} = state) do
+    if state.debug?, do: debug "ERROR: NICK IN USE"
+    send_event {:login_failed, :nick_in_use}, state
     {:noreply, state}
   end
   # Called when the server sends it's current capabilities

--- a/lib/exirc/example_handler.ex
+++ b/lib/exirc/example_handler.ex
@@ -42,6 +42,10 @@ defmodule ExampleHandler do
     debug "Logged in to server"
     {:noreply, nil}
   end
+  def handle_info({:login_failed, :nickname_in_use}, _state) do
+    debug "Login failed, nickname in use"
+    {:noreply, nil}
+  end
   def handle_info(:disconnected, _state) do
     debug "Disconnected from server"
     {:noreply, nil}

--- a/lib/exirc/example_handler.ex
+++ b/lib/exirc/example_handler.ex
@@ -42,7 +42,7 @@ defmodule ExampleHandler do
     debug "Logged in to server"
     {:noreply, nil}
   end
-  def handle_info({:login_failed, :nickname_in_use}, _state) do
+  def handle_info({:login_failed, :nick_in_use}, _state) do
     debug "Login failed, nickname in use"
     {:noreply, nil}
   end


### PR DESCRIPTION
Currently the login hangs if the nickname the bot tries to claim is in use. Added handling for the error server will return in this case and a callback message. The library user can then decide how to react to this, for example by dying gracefully or retrying with a different nick. It's enough to transmit a new `NICK` command to server at this point to achieve login.

I decided to namespace the login_failed message, so similar handling can be added for failed password attempt etc.

Example provided in ExampleBot how to recover and continue login with a randomized nick.