### PR TITLE
Implementation of Whois feature.

### DIFF
--- a/lib/exirc/channels.ex
+++ b/lib/exirc/channels.ex
@@ -72,7 +72,7 @@ defmodule ExIrc.Channels do
   Update the type of a tracked channel when it changes
   """
   def set_type(channel_tree, channel_name, channel_type) when is_binary(channel_type) do
-    set_type(channel_tree, channel_name, String.to_char_list(channel_type))
+    set_type(channel_tree, channel_name, String.to_charlist(channel_type))
   end
   def set_type(channel_tree, channel_name, channel_type) do
     name = downcase(channel_name)
@@ -104,7 +104,7 @@ defmodule ExIrc.Channels do
   Add multiple users to a tracked channel (used primarily in conjunction with the NAMES command)
   """
   def users_join(channel_tree, channel_name, nicks) do
-    pnicks = strip_rank(nicks)
+    pnicks = trim_rank(nicks)
     manipfn = fn(channel_nicks) -> :lists.usort(channel_nicks ++ pnicks) end
     users_manip(channel_tree, channel_name, manipfn)
   end
@@ -113,13 +113,13 @@ defmodule ExIrc.Channels do
   Remove a user from a tracked channel when they leave
   """
   def user_part(channel_tree, channel_name, nick) do
-    pnick = strip_rank([nick])
+    pnick = trim_rank([nick])
     manipfn = fn(channel_nicks) -> :lists.usort(channel_nicks -- pnick) end
     users_manip(channel_tree, channel_name, manipfn)
   end
 
   def user_quit(channel_tree, nick) do
-    pnick = strip_rank([nick])
+    pnick = trim_rank([nick])
     manipfn = fn(channel_nicks) -> :lists.usort(channel_nicks -- pnick) end
     foldl = fn(channel_name, new_channel_tree) ->
       name = downcase(channel_name)
@@ -217,7 +217,7 @@ defmodule ExIrc.Channels do
     end
   end
 
-  defp strip_rank(nicks) do
+  defp trim_rank(nicks) do
     nicks |> Enum.map(fn(n) -> case n do
         << "@", nick :: binary >> -> nick
         << "+", nick :: binary >> -> nick

--- a/lib/exirc/commands.ex
+++ b/lib/exirc/commands.ex
@@ -49,7 +49,9 @@ defmodule Irc.Commands do
       #one of two replies is sent. If the topic is set, RPL_TOPIC is sent back else
       #RPL_NOTOPIC.
       #"""
-      @rpl_whoiregnick "307"
+      @rpl_whoiscertfp "276"
+      @rpl_whoisregnick "307"
+      @rpl_whoishelpop "310"
       @rpl_whoisuser "311"
       @rpl_whoisserver "312"
       @rpl_whoisoperator "313"
@@ -203,7 +205,7 @@ defmodule Irc.Commands do
   @doc """
   Send a WHOIS request about a user
   """
-  def whois!(user), do: command! ['WHOIS', user]
+  def whois!(user), do: command! ['WHOIS ', user]
 
   @doc """
   Send password to server

--- a/lib/exirc/commands.ex
+++ b/lib/exirc/commands.ex
@@ -49,6 +49,14 @@ defmodule Irc.Commands do
       #one of two replies is sent. If the topic is set, RPL_TOPIC is sent back else
       #RPL_NOTOPIC.
       #"""
+      @rpl_whoiregnick "307"
+      @rpl_whoisuser "311"
+      @rpl_whoisserver "312"
+      @rpl_whoisoperator "313"
+      @rpl_whoisidle "317"
+      @rpl_endofwhois "318"
+      @rpl_whoischannels "319"
+      @rpl_whoisaccount "330"
       @rpl_notopic "331"
       @rpl_topic "332"
       #@doc """
@@ -77,6 +85,8 @@ defmodule Irc.Commands do
       @rpl_motd "372"
       @rpl_motdstart "375"
       @rpl_endofmotd "376"
+      @rpl_whoishost "378"
+      @rpl_whoismodes "379"
 
       ################
       # Error Codes
@@ -150,6 +160,8 @@ defmodule Irc.Commands do
       #"""
       @err_restricted "484"
 
+      @rpl_whoissecure "671"
+
       ###############
       # Code groups
       ###############
@@ -158,6 +170,12 @@ defmodule Irc.Commands do
                       @err_nickname_in_use,     @err_nick_collision,
                       @err_unavail_resource,    @err_need_more_params,
                       @err_already_registered,  @err_restricted ]
+
+      @whois_rpls [ @rpl_whoisuser,  @rpl_whoishost,
+                    @rpl_whoishost,  @rpl_whoisserver,
+                    @rpl_whoismodes, @rpl_whoisidle,
+                    @rpl_endofwhois
+                  ]
     end
 
   end
@@ -181,6 +199,11 @@ defmodule Irc.Commands do
   end
 
   # IRC Commands
+
+  @doc """
+  Send a WHOIS request about a user
+  """
+  def whois!(user), do: command! ['WHOIS', user]
 
   @doc """
   Send password to server

--- a/lib/exirc/logger.ex
+++ b/lib/exirc/logger.ex
@@ -8,7 +8,7 @@ defmodule ExIrc.Logger do
   """
   @spec info(binary) :: :ok
   def info(msg) do
-    :error_logger.info_report String.to_char_list(msg)
+    :error_logger.info_report String.to_charlist(msg)
   end
 
   @doc """
@@ -16,7 +16,7 @@ defmodule ExIrc.Logger do
   """
   @spec warning(binary) :: :ok
   def warning(msg) do
-    :error_logger.warning_report String.to_char_list("#{IO.ANSI.yellow()}#{msg}#{IO.ANSI.reset()}")
+    :error_logger.warning_report String.to_charlist("#{IO.ANSI.yellow()}#{msg}#{IO.ANSI.reset()}")
   end
 
   @doc """
@@ -24,6 +24,6 @@ defmodule ExIrc.Logger do
   """
   @spec error(binary) :: :ok
   def error(msg) do
-    :error_logger.error_report String.to_char_list("#{IO.ANSI.red()}#{msg}#{IO.ANSI.reset()}")
+    :error_logger.error_report String.to_charlist("#{IO.ANSI.red()}#{msg}#{IO.ANSI.reset()}")
   end
 end

--- a/lib/exirc/utils.ex
+++ b/lib/exirc/utils.ex
@@ -13,7 +13,7 @@ defmodule ExIrc.Utils do
       message = ExIrc.Utils.parse data
       assert "irc.example.org" = message.server
   """
-  @spec parse(raw_data :: char_list) :: IrcMessage.t
+  @spec parse(raw_data :: charlist) :: IrcMessage.t
   def parse(raw_data) do
     data = :string.substr(raw_data, 1, length(raw_data))
     case data do
@@ -137,7 +137,7 @@ defmodule ExIrc.Utils do
   end
   defp isup_param("PREFIX=" <> user_prefixes, state) do
     prefixes = Regex.run(~r/\((.*)\)(.*)/, user_prefixes, capture: :all_but_first)
-               |> Enum.map(&String.to_char_list/1)
+               |> Enum.map(&String.to_charlist/1)
                |> List.zip
     %{state | user_prefixes: prefixes}
   end
@@ -167,15 +167,15 @@ defmodule ExIrc.Utils do
      ' ',
      :lists.nth(m, @months_of_year),
      ' ',
-     :io_lib.format("~2..0s", [Integer.to_char_list(d)]),
+     :io_lib.format("~2..0s", [Integer.to_charlist(d)]),
      ' ',
-     :io_lib.format("~2..0s", [Integer.to_char_list(h)]),
+     :io_lib.format("~2..0s", [Integer.to_charlist(h)]),
      ':',
-     :io_lib.format("~2..0s", [Integer.to_char_list(n)]),
+     :io_lib.format("~2..0s", [Integer.to_charlist(n)]),
      ':',
-     :io_lib.format("~2..0s", [Integer.to_char_list(s)]),
+     :io_lib.format("~2..0s", [Integer.to_charlist(s)]),
      ' ',
-     Integer.to_char_list(y)] |> List.flatten |> List.to_string
+     Integer.to_charlist(y)] |> List.flatten |> List.to_string
   end
 
   defp trim_crlf(charlist) do

--- a/lib/exirc/whois.ex
+++ b/lib/exirc/whois.ex
@@ -1,0 +1,18 @@
+defmodule Irc.Whois do
+  defstruct [account_name: nil,
+             channels: [],
+             helpop?: false,
+             hostname: nil,
+             idling_time: 0,
+             ircop?: false,
+             nickname: nil,
+             realname: nil,
+             registered_nick?: false,
+             server_address: nil,
+             server_name: nil,
+             signon_time: 0,
+             tls?: false,
+             username: nil,
+            ]
+end
+


### PR DESCRIPTION
### Summary of the changes
Hi @bitwalker! I have made the following changes in the code base:

* Implemented the relevant `handle_data` functions to catch the messages
* Added the numerics in `Irc.Commands`, except for `@rpl_whoismodes` that I have not encountered yet.
* Added a `whois_buffers` key in `%ClientState` to store the intermediate results.
* Added an `%Irc.Whois{}` struct to enforce the authorized keys and ensure data integrity and document the available fields.
* Updated the code to use the non-deprecated versions of `String.strip` and `String.to_char_list`.