### PR TITLE
Add WHO query

### DIFF
--- a/lib/exirc/client.ex
+++ b/lib/exirc/client.ex
@@ -689,7 +689,7 @@ defmodule ExIRC.Client do
     away?               = String.contains?(mode, "G")
     founder?            = String.contains?(mode, "~")
     half_operator?      = String.contains?(mode, "%")
-    operator?           = String.contains?(mode, "@")
+    operator?           = founder? || admin? || String.contains?(mode, "@")
     server_operator?    = String.contains?(mode, "*")
     voiced?             = String.contains?(mode, "+")
 

--- a/lib/exirc/client.ex
+++ b/lib/exirc/client.ex
@@ -694,7 +694,7 @@ defmodule ExIRC.Client do
     voiced?             = String.contains?(mode, "+")
 
      nick = %{nick: nick, user: user, name: name, server: server, hops: hop, admin?: admin?,
-              away?: away, founder?: founder, half_operator?: half_operator?,
+              away?: away?, founder?: founder?, half_operator?: half_operator?,
               operator?: operator?, server_operator?: server_operator?, voiced?: voiced?
              }
 

--- a/lib/exirc/client.ex
+++ b/lib/exirc/client.ex
@@ -703,7 +703,11 @@ defmodule ExIRC.Client do
   end
 
   def handle_data(%ExIRC.Message{:cmd => "315", :args => [_, channel, _]}, state) do
-    buffer = Map.get(state.who_buffers, channel, [])
+    buffer = state
+             |> Map.get(:who_buffers)
+             |> Map.get(channel)
+             |> Enum.map(fn user -> struct(ExIRC.Who, user) end)
+
     send_event {:who, channel, buffer}, state
     {:noreply, %ClientState{state | who_buffers: Map.delete(state.who_buffers, channel)}}
   end

--- a/lib/exirc/client.ex
+++ b/lib/exirc/client.ex
@@ -683,10 +683,21 @@ defmodule ExIRC.Client do
 
    def handle_data(%ExIRC.Message{:cmd => "352", :args => [_, channel, user, host, server, nick, mode, hop_and_realn]}, state) do
     [hop, name] = String.split(hop_and_realn, " ", parts: 2)
+
     :binary.compile_pattern(["@", "&", "+"])
-    operator? = String.contains?(mode, "@")
-    voiced?   = String.contains?(mode, "+")
-    nick = %{nick: nick, user: user, name: name, server: server, hops: hop, operator?: operator?, voiced?: voiced?}
+    admin?              = String.contains?(mode, "&")
+    away?               = String.contains?(mode, "G")
+    founder?            = String.contains?(mode, "~")
+    half_operator?      = String.contains?(mode, "%")
+    operator?           = String.contains?(mode, "@")
+    server_operator?    = String.contains?(mode, "*")
+    voiced?             = String.contains?(mode, "+")
+
+     nick = %{nick: nick, user: user, name: name, server: server, hops: hop, admin?: admin?,
+              away?: away, founder?: founder, half_operator?: half_operator?,
+              operator?: operator?, server_operator?: server_operator?, voiced?: voiced?
+             }
+
     buffer = Map.get(state.who_buffers, channel, [])
     {:noreply, %ClientState{state | who_buffers: Map.put(state.who_buffers, channel, [nick|buffer])}}
   end

--- a/lib/exirc/commands.ex
+++ b/lib/exirc/commands.ex
@@ -208,6 +208,11 @@ defmodule ExIRC.Commands do
   def whois!(user), do: command! ['WHOIS ', user]
 
   @doc """
+  Send a WHO request about a channel
+  """
+  def who!(channel), do: command! ['WHO ', channel]
+
+  @doc """
   Send password to server
   """
   def pass!(pwd), do: command! ['PASS ', pwd]

--- a/lib/exirc/who.ex
+++ b/lib/exirc/who.ex
@@ -1,9 +1,17 @@
 defmodule ExIRC.Who do
 
-  defstruct [name: nil,
+  defstruct [
+             admin?: nil,
+             away?: nil,
+             founder?: nil,
+             half_operator?: nil,
+             hops: nil,
+             name: nil,
              nickname: nil,
              operator?: nil,
              server: nil,
-             user: nil
+             server_operator?: nil,
+             user: nil,
+             voiced?: nil
             ]
 end

--- a/lib/exirc/who.ex
+++ b/lib/exirc/who.ex
@@ -1,0 +1,9 @@
+defmodule ExIRC.Who do
+
+  defstruct [name: nil,
+             nickname: nil,
+             operator?: nil,
+             server: nil,
+             user: nil
+            ]
+end

--- a/lib/exirc/whois.ex
+++ b/lib/exirc/whois.ex
@@ -12,7 +12,7 @@ defmodule ExIRC.Whois do
              server_address: nil,
              server_name: nil,
              signon_time: 0,
-             tls?: false,
+             ssl?: false,
              username: nil,
             ]
 end


### PR DESCRIPTION
This PR adds the ability to perform and parse WHO queries on channels. Moreover, it provides fields like `operator?` and `voiced?` that may be used to build a list of ops/voiced. Those fields will expand in the future when experience and/or complaints discover more of them.