### PR TITLE
Terminology harmonization

### DIFF
--- a/lib/exirc/client.ex
+++ b/lib/exirc/client.ex
@@ -99,7 +99,7 @@ defmodule ExIRC.Client do
   Logon to a server
 
   Example:
-    Client.logon pid, "password", "mynick", "username", "My Name"
+    Client.logon pid, "password", "mynick", "user", "My Name"
   """
   @spec logon(client :: pid, pass :: binary, nick :: binary, user :: binary, name :: binary) :: :ok | {:error, :not_connected}
   def logon(client, pass, nick, user, name) do
@@ -624,8 +624,8 @@ defmodule ExIRC.Client do
 
   ## WHOIS
 
-  def handle_data(%ExIRC.Message{cmd: @rpl_whoisuser, args: [_sender, nick, username, hostname, _, realname]}, state) do
-    user = %{nick: nick, username: username, hostname: hostname, realname: realname}
+  def handle_data(%ExIRC.Message{cmd: @rpl_whoisuser, args: [_sender, nick, user, hostname, _, name]}, state) do
+    user = %{nick: nick, user: user, hostname: hostname, name: name}
     {:noreply, %ClientState{state|whois_buffers: Map.put(state.whois_buffers, nick, user)}}
   end
 

--- a/lib/exirc/client.ex
+++ b/lib/exirc/client.ex
@@ -624,59 +624,59 @@ defmodule ExIRC.Client do
 
   ## WHOIS
 
-  def handle_data(%ExIRC.Message{cmd: @rpl_whoisuser, args: [_sender, nickname, username, hostname, _, realname]}, state) do
-    user = %{nickname: nickname, username: username, hostname: hostname, realname: realname}
-    {:noreply, %ClientState{state|whois_buffers: Map.put(state.whois_buffers, nickname, user)}}
+  def handle_data(%ExIRC.Message{cmd: @rpl_whoisuser, args: [_sender, nick, username, hostname, _, realname]}, state) do
+    user = %{nick: nick, username: username, hostname: hostname, realname: realname}
+    {:noreply, %ClientState{state|whois_buffers: Map.put(state.whois_buffers, nick, user)}}
   end
 
-  def handle_data(%ExIRC.Message{cmd: @rpl_whoiscertfp, args: [_sender, nickname, "has client certificate fingerprint "<> fingerprint]}, state) do
-    {:noreply, %ClientState{state|whois_buffers: put_in(state.whois_buffers, [nickname, :certfp], fingerprint)}}
+  def handle_data(%ExIRC.Message{cmd: @rpl_whoiscertfp, args: [_sender, nick, "has client certificate fingerprint "<> fingerprint]}, state) do
+    {:noreply, %ClientState{state|whois_buffers: put_in(state.whois_buffers, [nick, :certfp], fingerprint)}}
   end
 
-  def handle_data(%ExIRC.Message{cmd: @rpl_whoisregnick, args: [_sender, nickname, _message]}, state) do
-    {:noreply, %ClientState{state|whois_buffers: put_in(state.whois_buffers, [nickname, :registered_nick?], true)}}
+  def handle_data(%ExIRC.Message{cmd: @rpl_whoisregnick, args: [_sender, nick, _message]}, state) do
+    {:noreply, %ClientState{state|whois_buffers: put_in(state.whois_buffers, [nick, :registered_nick?], true)}}
   end
 
-  def handle_data(%ExIRC.Message{cmd: @rpl_whoishelpop, args: [_sender, nickname, _message]}, state) do
-    {:noreply, %ClientState{state|whois_buffers: put_in(state.whois_buffers, [nickname, :helpop?], true)}}
+  def handle_data(%ExIRC.Message{cmd: @rpl_whoishelpop, args: [_sender, nick, _message]}, state) do
+    {:noreply, %ClientState{state|whois_buffers: put_in(state.whois_buffers, [nick, :helpop?], true)}}
   end
 
-  def handle_data(%ExIRC.Message{cmd: @rpl_whoischannels, args: [_sender, nickname, channels]}, state) do
+  def handle_data(%ExIRC.Message{cmd: @rpl_whoischannels, args: [_sender, nick, channels]}, state) do
     chans = String.split(channels, " ")
-    {:noreply, %ClientState{state|whois_buffers: put_in(state.whois_buffers, [nickname, :channels], chans)}}
+    {:noreply, %ClientState{state|whois_buffers: put_in(state.whois_buffers, [nick, :channels], chans)}}
   end
 
 
-  def handle_data(%ExIRC.Message{cmd: @rpl_whoisserver, args: [_sender, nickname, server_addr, server_name]}, state) do
+  def handle_data(%ExIRC.Message{cmd: @rpl_whoisserver, args: [_sender, nick, server_addr, server_name]}, state) do
     new_buffer = state.whois_buffers
-                 |> put_in([nickname, :server_name], server_name)
-                 |> put_in([nickname, :server_address], server_addr)
+                 |> put_in([nick, :server_name], server_name)
+                 |> put_in([nick, :server_address], server_addr)
     {:noreply, %ClientState{state|whois_buffers: new_buffer}}
   end
 
-  def handle_data(%ExIRC.Message{cmd: @rpl_whoisoperator, args: [_sender, nickname, _message]}, state) do
-    {:noreply, %ClientState{state|whois_buffers: put_in(state.whois_buffers, [nickname, :ircop?], true)}}
+  def handle_data(%ExIRC.Message{cmd: @rpl_whoisoperator, args: [_sender, nick, _message]}, state) do
+    {:noreply, %ClientState{state|whois_buffers: put_in(state.whois_buffers, [nick, :ircop?], true)}}
   end
 
-  def handle_data(%ExIRC.Message{cmd: @rpl_whoisaccount, args: [_sender, nickname, account_name, _message]}, state) do
-    {:noreply, %ClientState{state|whois_buffers: put_in(state.whois_buffers, [nickname, :account_name], account_name)}}
+  def handle_data(%ExIRC.Message{cmd: @rpl_whoisaccount, args: [_sender, nick, account_name, _message]}, state) do
+    {:noreply, %ClientState{state|whois_buffers: put_in(state.whois_buffers, [nick, :account_name], account_name)}}
   end
 
-  def handle_data(%ExIRC.Message{cmd: @rpl_whoissecure, args: [_sender, nickname, _message]}, state) do
-    {:noreply, %ClientState{state|whois_buffers: put_in(state.whois_buffers, [nickname, :ssl?], true)}}
+  def handle_data(%ExIRC.Message{cmd: @rpl_whoissecure, args: [_sender, nick, _message]}, state) do
+    {:noreply, %ClientState{state|whois_buffers: put_in(state.whois_buffers, [nick, :ssl?], true)}}
   end
 
-  def handle_data(%ExIRC.Message{cmd: @rpl_whoisidle, args: [_sender, nickname, idling_time, signon_time, _message]}, state) do
+  def handle_data(%ExIRC.Message{cmd: @rpl_whoisidle, args: [_sender, nick, idling_time, signon_time, _message]}, state) do
     new_buffer = state.whois_buffers
-                 |> put_in([nickname, :idling_time], idling_time)
-                 |> put_in([nickname, :signon_time], signon_time)
+                 |> put_in([nick, :idling_time], idling_time)
+                 |> put_in([nick, :signon_time], signon_time)
     {:noreply, %ClientState{state|whois_buffers: new_buffer}}
   end
 
-  def handle_data(%ExIRC.Message{cmd: @rpl_endofwhois, args: [_sender, nickname, _message]}, state) do
-    buffer = struct(ExIRC.Whois, state.whois_buffers[nickname])
+  def handle_data(%ExIRC.Message{cmd: @rpl_endofwhois, args: [_sender, nick, _message]}, state) do
+    buffer = struct(ExIRC.Whois, state.whois_buffers[nick])
     send_event {:whois, buffer}, state
-    {:noreply, %ClientState{state|whois_buffers: Map.delete(state.whois_buffers, nickname)}}
+    {:noreply, %ClientState{state|whois_buffers: Map.delete(state.whois_buffers, nick)}}
   end
 
   ## WHO

--- a/lib/exirc/client.ex
+++ b/lib/exirc/client.ex
@@ -694,7 +694,7 @@ defmodule ExIRC.Client do
     voiced?             = String.contains?(mode, "+")
 
      nick = %{nick: nick, user: user, name: name, server: server, hops: hop, admin?: admin?,
-              away?: away?, founder?: founder?, half_operator?: half_operator?,
+              away?: away?, founder?: founder?, half_operator?: half_operator?, host: host,
               operator?: operator?, server_operator?: server_operator?, voiced?: voiced?
              }
 

--- a/lib/exirc/commands.ex
+++ b/lib/exirc/commands.ex
@@ -95,7 +95,7 @@ defmodule ExIRC.Commands do
       ################
 
       #@doc """
-      #Used to indicate the nickname parameter supplied to a command is currently unused.
+      #Used to indicate the nick parameter supplied to a command is currently unused.
       #"""
       @err_no_such_nick "401"
       #@doc """
@@ -122,20 +122,20 @@ defmodule ExIRC.Commands do
       #"""
       @err_unknown_command "421"
       #@doc """
-      #Returned when a nickname parameter expected for a command and isn"t found.
+      #Returned when a nick parameter expected for a command and isn"t found.
       #"""
-      @err_no_nickname_given "431"
+      @err_no_nick_given "431"
       #@doc """
       #Returned after receiving a NICK message which contains characters which do not fall in the defined set.
       #"""
-      @err_erroneus_nickname "432"
+      @err_erroneus_nick "432"
       #@doc """
       #Returned when a NICK message is processed that results in an attempt to 
-      #change to a currently existing nickname.
+      #change to a currently existing nick.
       #"""
-      @err_nickname_in_use "433"
+      @err_nick_in_use "433"
       #@doc """
-      #Returned by a server to a client when it detects a nickname collision
+      #Returned by a server to a client when it detects a nick collision
       #(registered of a NICK that already exists by another server).
       #"""
       @err_nick_collision "436"
@@ -168,8 +168,8 @@ defmodule ExIRC.Commands do
       # Code groups
       ###############
 
-      @logon_errors [ @err_no_nickname_given,   @err_erroneus_nickname,
-                      @err_nickname_in_use,     @err_nick_collision,
+      @logon_errors [ @err_no_nick_given,   @err_erroneus_nick,
+                      @err_nick_in_use,     @err_nick_collision,
                       @err_unavail_resource,    @err_need_more_params,
                       @err_already_registered,  @err_restricted ]
 

--- a/lib/exirc/who.ex
+++ b/lib/exirc/who.ex
@@ -7,7 +7,7 @@ defmodule ExIRC.Who do
              half_operator?: nil,
              hops: nil,
              name: nil,
-             nickname: nil,
+             nick: nil,
              operator?: nil,
              server: nil,
              server_operator?: nil,

--- a/lib/exirc/who.ex
+++ b/lib/exirc/who.ex
@@ -6,6 +6,7 @@ defmodule ExIRC.Who do
              founder?: nil,
              half_operator?: nil,
              hops: nil,
+             host: nil,
              name: nil,
              nick: nil,
              operator?: nil,

--- a/lib/exirc/whois.ex
+++ b/lib/exirc/whois.ex
@@ -6,7 +6,7 @@ defmodule ExIRC.Whois do
              hostname: nil,
              idling_time: 0,
              ircop?: false,
-             nickname: nil,
+             nick: nil,
              realname: nil,
              registered_nick?: false,
              server_address: nil,

--- a/lib/exirc/whois.ex
+++ b/lib/exirc/whois.ex
@@ -7,13 +7,13 @@ defmodule ExIRC.Whois do
              idling_time: 0,
              ircop?: false,
              nick: nil,
-             realname: nil,
+             name: nil,
              registered_nick?: false,
              server_address: nil,
              server_name: nil,
              signon_time: 0,
              ssl?: false,
-             username: nil,
+             user: nil,
             ]
 end
 


### PR DESCRIPTION
In an effort to keep a consistent codebase and facilitate our future work with ExIRC, I open this PR to submit an harmonization of the code regarding the use of `nick` and `nickname`.
This PR turns all occurrences of `nickname` to `nick`, as the latter being more widely used throughout the codebase.

@bitwalker 
@hrefhref 

Your opinion?