### PR TITLE
Add a few client tests

### DIFF
--- a/test/client_test.exs
+++ b/test/client_test.exs
@@ -1,5 +1,9 @@
 defmodule ExIRC.ClientTest do
-  use ExUnit.Case
+  use ExUnit.Case, async: false
+  use ExIRC.Commands
+
+  alias ExIRC.Client
+  alias ExIRC.SenderInfo
 
   test "start multiple clients" do
     assert {:ok, pid} = ExIRC.start_client!
@@ -26,5 +30,76 @@ defmodule ExIRC.ClientTest do
     send(pid, :stop)
     :timer.sleep(1)
     refute Process.alive?(client_pid)
+  end
+
+  test "login sends event to handler" do
+    state = get_state()
+    state = %{state | logged_on?: false, channels: []}
+    msg = %ExIRC.Message{cmd: @rpl_welcome}
+    {:noreply, new_state} = Client.handle_data(msg, state)
+    assert new_state.logged_on? == true
+    assert_receive :logged_in, 10
+  end
+
+  test "login failed with nick in use sends event to handler" do
+    state = get_state()
+    state = %{state | logged_on?: false}
+    msg = %ExIRC.Message{cmd: @err_nick_in_use}
+    {:noreply, new_state} = Client.handle_data(msg, state)
+    assert new_state.logged_on? == false
+    assert_receive {:login_failed, :nick_in_use}, 10
+  end
+
+  test "own nick change sends event to handler" do
+    state = get_state()
+    msg = %ExIRC.Message{nick: state.nick, cmd: "NICK", args: ["new_nick"]}
+    {:noreply, new_state} = Client.handle_data(msg, state)
+    assert new_state.nick == "new_nick"
+    assert_receive {:nick_changed, "new_nick"}, 10
+  end
+
+  test "receiving private message sends event to handler" do
+    state = get_state()
+    msg = %ExIRC.Message{nick: "other_user", cmd: "PRIVMSG", args: [state.nick, "message"], host: "host", user: "user"}
+    Client.handle_data(msg, state)
+    expected_senderinfo = %SenderInfo{nick: "other_user", host: "host", user: "user"}
+    assert_receive {:received, "message", expected_senderinfo}, 10
+  end
+
+  test "receiving channel message sends event to handler" do
+    state = get_state()
+    msg = %ExIRC.Message{nick: "other_user", cmd: "PRIVMSG", args: ["#testchannel", "message"], host: "host", user: "user"}
+    Client.handle_data(msg, state)
+    expected_senderinfo = %SenderInfo{nick: "other_user", host: "host", user: "user"}
+    assert_receive {:received, "message", expected_senderinfo, "#testchannel"}, 10
+  end
+
+  test "receiving channel message with mention sends events to handler" do
+    state = get_state()
+    chat_message = "hi #{state.nick}!"
+    msg = %ExIRC.Message{nick: "other_user", cmd: "PRIVMSG", args: ["#testchannel", chat_message], host: "host", user: "user"}
+    Client.handle_data(msg, state)
+    expected_senderinfo = %SenderInfo{nick: "other_user", host: "host", user: "user"}
+    assert_receive {:received, chat_message, expected_senderinfo, "#testchannel"}, 10
+    assert_receive {:mentioned, chat_message, expected_senderinfo, "#testchannel"}, 10
+  end
+
+  defp get_state() do
+    %ExIRC.Client.ClientState{
+      nick: "tester",
+      logged_on?: true,
+      event_handlers: [{self(), Process.monitor(self())}],
+      channels: [get_channel()],
+    }
+  end
+
+  defp get_channel() do
+    %ExIRC.Channels.Channel{
+      name: "testchannel",
+      topic: "topic",
+      users: [],
+      modes: '',
+      type: ''
+    }
   end
 end


### PR DESCRIPTION
I noticed there are hardly any tests for the client code. I was thinking about how to test genservers in Elixir and this is what I came up with. I call `handle_data` and expect a message to the handler process, which is actually the ExUnit process itself.

I'm open for discussion. Does this make any sense? Are there better conventions for testing in Elixir?